### PR TITLE
Fixes a regex error (item/rat`var`/something)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.1.1
-* Fixed a regex error that causes a wrong detection
+* Fixed a regex error that causes a wrong detection of var
 
 ## 0.1.0 - First Release
 * Every feature added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.1
+* Fixed a regex error that causes a wrong detection
+
 ## 0.1.0 - First Release
 * Every feature added
 * Every bug fixed

--- a/grammars/dream maker.cson
+++ b/grammars/dream maker.cson
@@ -25,7 +25,7 @@ patterns: [
 	}
 	{
 		match: '''(?x)
-		(?:^|[\\s\\t\\(])(var)[\\/ ]
+		(?:\\b(var))[\\/ ]
 		(?:(static|global|tmp|const)\\/)?
 		(?:(datum|atom(?:\\/movable)?|obj|mob|turf|area|savefile|list|client|sound|image|database|matrix|regex|exception)\\/)?
 		(?:
@@ -40,9 +40,9 @@ patterns: [
 				name: "storage.type.dm"
 			"2":
 				name: "storage.modifier.dm"
-			"4":
+			"3":
 				name: "storage.type.dm"
-			"6":
+			"5":
 				name: "variable.other.dm"
 	}
 	{

--- a/grammars/dream maker.cson
+++ b/grammars/dream maker.cson
@@ -25,7 +25,7 @@ patterns: [
 	}
 	{
 		match: '''(?x)
-		(?:^|[\s\t\(])(var)[\\/ ]
+		(?:^|[\\s\\t\\(])(var)[\\/ ]
 		(?:(static|global|tmp|const)\\/)?
 		(?:(datum|atom(?:\\/movable)?|obj|mob|turf|area|savefile|list|client|sound|image|database|matrix|regex|exception)\\/)?
 		(?:

--- a/grammars/dream maker.cson
+++ b/grammars/dream maker.cson
@@ -25,7 +25,7 @@ patterns: [
 	}
 	{
 		match: '''(?x)
-		(var)[\\/ ]
+		(?:^|[\s\t\(])(var)[\\/ ]
 		(?:(static|global|tmp|const)\\/)?
 		(?:(datum|atom(?:\\/movable)?|obj|mob|turf|area|savefile|list|client|sound|image|database|matrix|regex|exception)\\/)?
 		(?:
@@ -40,9 +40,9 @@ patterns: [
 				name: "storage.type.dm"
 			"2":
 				name: "storage.modifier.dm"
-			"3":
+			"4":
 				name: "storage.type.dm"
-			"5":
+			"6":
 				name: "variable.other.dm"
 	}
 	{


### PR DESCRIPTION
* Closes #8

![image](https://github.com/PJB3005/atomic-dreams/assets/87972842/eac60a55-9d24-4451-9cf4-8bc40afb8732)

The image is the error that it catches a wrong detection about var

I added a regex condition for var `\b`